### PR TITLE
use lowercase naming to support case sensitive OS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ var _reactDom = require("react-dom");
 
 var _reactDom2 = _interopRequireDefault(_reactDom);
 
-require("Stickyfill");
+require("stickyfill");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "webpack": "^4.38.0"
   },
   "dependencies": {
-    "Stickyfill": "git+https://github.com/seleckis/stickyfill.git",
+    "stickyfill": "git+https://github.com/infogram/stickyfill.git#90526ae",
     "prop-types": "^15.5.10"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 import React, {Component} from "react";
 import PropTypes from 'prop-types';
 import ReactDOM from "react-dom";
-import 'Stickyfill';
+import 'stickyfill';
 
 export default class Sticker extends Component {
 	static propTypes = {


### PR DESCRIPTION
atm not using lowercase naming breaks stuff on OS which are case sensitive and using webpack.